### PR TITLE
Updated gtk-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["external-ffi-bindings"]
 travis-ci = { repository = "qdot/libappindicator-sys" }
 
 [dependencies]
-gtk-sys = "0.3"
+gtk-sys = "0.4"
 
 [build-dependencies]
 bindgen = "0.22"


### PR DESCRIPTION
This was causing some issues when trying to add appindicator support for an app using a newer version of gtk.