### PR TITLE
Update gtk-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["external-ffi-bindings"]
 travis-ci = { repository = "qdot/libappindicator-sys" }
 
 [dependencies]
-gtk-sys = "0.4"
+gtk-sys = "0.5"
 
 [build-dependencies]
 bindgen = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libappindicator-sys"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Kyle Machulis <kyle@nonpolynomial.com>"]
 description = "Rust raw bindings for libappindicator"
 license = "LGPL-2.1/LGPL-3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+
 extern crate gtk_sys;
-use gtk_sys::{GtkStatusIconPrivate, GtkStatusIcon, GtkMenu, GtkWidget};
+
+use gtk_sys::{GtkStatusIcon, GtkMenu, GtkWidget};
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Updates the library so that it uses the latest gtk-sys versions. The pull request for `libappindicator-rs` will follow.

**Rationale:** currently both libraries use different versions for `gtk` and `gtk-sys` dependencies. When linking the libraries with other projects or even when using `libappindicator-rs` directly, it shows link errors because of that, so it's better to stick to the same version (to the latest stable one), that's why I decided to update the libraries (`libappindicator-rs` is also updated, I will send a pull request, when this pull request is approved and merged).