### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ travis-ci = { repository = "qdot/libappindicator-sys" }
 
 [dependencies]
 gtk-sys = "0.7"
+glib-sys = "0.7"
+gobject-sys = "0.7"
+gdk-sys = "0.7"
 
 [build-dependencies]
 bindgen = "0.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ travis-ci = { repository = "qdot/libappindicator-sys" }
 gtk-sys = "0.6"
 
 [build-dependencies]
-bindgen = "0.22"
+bindgen = "0.42"
 pkg-config = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["external-ffi-bindings"]
 travis-ci = { repository = "qdot/libappindicator-sys" }
 
 [dependencies]
-gtk-sys = "0.6"
+gtk-sys = "0.7"
 
 [build-dependencies]
 bindgen = "0.42"

--- a/build.rs
+++ b/build.rs
@@ -27,8 +27,6 @@ fn write_bindings(library : pkg_config::Library) {
         .expect("Couldn't write bindings!");
 }
 fn main() {
-    println!("cargo:rustc-link-lib=appindicator3");
-
     match pkg_config::probe_library("appindicator3") {
         Ok(library) => write_bindings(library),
         Err(_) => {

--- a/build.rs
+++ b/build.rs
@@ -6,12 +6,12 @@ use std::path::PathBuf;
 
 fn write_bindings(library : pkg_config::Library) {
     let mut bindings = bindgen::Builder::default()
-        .no_unstable_rust()
+        .rust_target(bindgen::RustTarget::Stable_1_25)
         .header("wrapper.h")
         // Hide Gtk types, as these will be filled in via gtk-sys
-        .hide_type("Gtk.*")
-        .whitelisted_type(".*AppIndicator.*")
-        .whitelisted_function("app_indicator_.*");
+        .blacklist_type("Gtk.*")
+        .whitelist_type(".*AppIndicator.*")
+        .whitelist_function("app_indicator_.*");
 
     for p in library.include_paths {
         bindings = bindings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 
 extern crate gtk_sys;
 
-use gtk_sys::{GtkStatusIcon, GtkMenu, GtkWidget};
+use gtk_sys::{
+    GtkContainer, GtkContainerPrivate, GtkMenu, GtkMenuPrivate, GtkMenuShell, GtkMenuShellPrivate,
+    GtkStatusIcon, GtkStatusIconPrivate, GtkWidget, GtkWidgetPrivate,
+};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,14 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+extern crate gdk_sys;
+extern crate glib_sys;
+extern crate gobject_sys;
 extern crate gtk_sys;
 
-use gtk_sys::{
-    GtkContainer, GtkContainerPrivate, GtkMenu, GtkMenuPrivate, GtkMenuShell, GtkMenuShellPrivate,
-    GtkStatusIcon, GtkStatusIconPrivate, GtkWidget, GtkWidgetPrivate,
-};
+use gdk_sys::GdkScrollDirection;
+use glib_sys::{gboolean, gpointer, GType};
+use gobject_sys::{GObject, GObjectClass};
+use gtk_sys::{GtkMenu, GtkStatusIcon, GtkWidget};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
This set of patches bumps the `libappindicator-sys` dependencies from the relatively ancient `bindgen 0.22` and `gtk-sys 0.6` to their latest versions (0.42 and 0.7 respectively). I also include a small fix that eliminates a redunant linker flag warning.